### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: CI
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Limit GITHUB_TOKEN permissions to read-only access for security
     permissions:
       contents: read
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/keyasuda/llm-batch-processor/security/code-scanning/1](https://github.com/keyasuda/llm-batch-processor/security/code-scanning/1)

The best fix is to add an explicit `permissions` block with `contents: read` at the job level for the `test` job (or globally at the workflow root, but using the job level is safest to avoid any unintentional permission changes for other jobs that could be added later). This limits the GITHUB_TOKEN to read-only access to repository contents during workflow execution, which is sufficient for all current steps. Edit the `.github/workflows/test.yml` file such that the `test` job includes:

```yaml
permissions:
  contents: read
```

This block should be inserted after the `runs-on` (or `environment`) field and before existing fields (`strategy`). No other imports or changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
